### PR TITLE
Fix double-free in ZoneType

### DIFF
--- a/mapgraph/typeregistry.h
+++ b/mapgraph/typeregistry.h
@@ -32,8 +32,8 @@ struct TypeInfo
  */
 struct ZoneType
 {
-    /** Pointer to the registry entry; may be nullptr for "Unknown". */
-    std::shared_ptr<const TypeInfo> info;
+    /** Pointer to the registry entry; not owned. May be nullptr for "Unknown". */
+    const TypeInfo* info{nullptr};
 
     /* convenience ctors */
     ZoneType()  = default;
@@ -74,7 +74,7 @@ namespace std
     {
         size_t operator()(const ZoneType& z) const noexcept
         {
-            return std::hash<std::shared_ptr<const TypeInfo>>{}(z.info);
+            return std::hash<const TypeInfo*>{}(z.info);
         }
     };
 }


### PR DESCRIPTION
## Summary
- avoid managing `TypeInfo` lifetime from `ZoneType`

## Testing
- `cmake ..` *(fails: Could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68647cb590f08332bb1bd8bd988f8ae9