### PR TITLE
Add unknown region dissolution step

### DIFF
--- a/preparing/mappreprocessing.hpp
+++ b/preparing/mappreprocessing.hpp
@@ -39,6 +39,14 @@ public:
     /** Generate a denoised map and cropping info using Segmentation helpers. */
     static std::pair<cv::Mat, Segmentation::CropInfo> generateDenoisedAlone(const cv::Mat& raw, const DenoiseConfig& config);
 
+    /**
+     * Resolve unknown (grey) regions by iteratively expanding black and
+     * white areas until convergence.
+     */
+    static cv::Mat unknownRegionsDissolution(const cv::Mat& src,
+                                             int kernelSize = 3,
+                                             int maxIter = 100);
+
     static bool mapAlign(const cv::Mat& raw, cv::Mat& out, const AlignmentConfig& config);
 };
 


### PR DESCRIPTION
## Summary
- add a function that dissolves grey unknown areas by iteratively eroding and dilating
- run this step at the start of map denoising so the image is cleaned before segmentation

## Testing
- `cmake ..` *(fails: could not find `ament_cmake`)*

------
https://chatgpt.com/codex/tasks/task_e_68664df885108332ae7c0582f5cee6e8