### PR TITLE
Implement removal of isolated gray regions

### DIFF
--- a/preparing/mappreprocessing.hpp
+++ b/preparing/mappreprocessing.hpp
@@ -47,6 +47,11 @@ public:
                                              int kernelSize = 3,
                                              int maxIter = 100);
 
+    /**
+     * Remove grey regions that are not connected with black pixels.
+     */
+    static cv::Mat removeGrayIslands(const cv::Mat& src, int connectivity = 8);
+
     static bool mapAlign(const cv::Mat& raw, cv::Mat& out, const AlignmentConfig& config);
 };
 


### PR DESCRIPTION
## Summary
- add `removeGrayIslands` to delete gray areas not connected with black pixels
- call `removeGrayIslands` in `MapPreprocessing::generateDenoisedAlone`

## Testing
- `cmake ..` *(fails: could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68665b47f8e08332a94d0a5a8dcc7746